### PR TITLE
Fix: Guard uses properly injection during checking inside

### DIFF
--- a/test/hex/state/StateMachineTest.hx
+++ b/test/hex/state/StateMachineTest.hx
@@ -235,8 +235,8 @@ class StateMachineTest
 	{
 		Assert.equals( this.anonymous, this._controller.getCurrentState(), "'anonymous' should be current state" );
 		
-		this.user.addExitCommand( PrepareUserInfosMockCommand ).withGuards( [ function approve() : Bool { return false; } ] );
-		this.user.addEnterCommand( PrepareUserInfosMockCommand ).withGuards( [ function approve() : Bool { return false; } ] );
+		this.user.addExitCommand( PrepareUserInfosMockCommand ).withGuard( function approve() : Bool { return false; } );
+		this.user.addEnterCommand( PrepareUserInfosMockCommand ).withGuard( function approve() : Bool { return false; } );
 		
 		this._fireMessage( this.logAsUser );
 		


### PR DESCRIPTION
Plurial should be removed. This closes DoclerLabs/hexMachina#81
