### PR TITLE
renaming logger to commandLogger to logger

### DIFF
--- a/test/hex/state/mock/AnotherMockCommandWithRequest.hx
+++ b/test/hex/state/mock/AnotherMockCommandWithRequest.hx
@@ -13,13 +13,13 @@ class AnotherMockCommandWithRequest extends BasicCommand
 	public var code : String;
 	
 	@Inject
-	public var logger : IMockCommandLogger;
+	public var commandLogger : IMockCommandLogger;
 	
 	@Inject
 	public var parser : IParser<String>;
 	
 	override public function execute() : Void
 	{
-		this.logger.log( this.parser.parse( this.code ) );
+		this.commandLogger.log( this.parser.parse( this.code ) );
 	}
 }

--- a/test/hex/state/mock/DeleteAllCookiesMockCommand.hx
+++ b/test/hex/state/mock/DeleteAllCookiesMockCommand.hx
@@ -9,10 +9,10 @@ import hex.control.command.BasicCommand;
 class DeleteAllCookiesMockCommand extends BasicCommand
 {
 	@Inject
-	public var logger : IMockCommandLogger;
+	public var commandLogger : IMockCommandLogger;
 
 	override public function execute() : Void
 	{
-		this.logger.log( "DAC" );
+		this.commandLogger.log( "DAC" );
 	}
 }

--- a/test/hex/state/mock/DisplayAddBannerMockCommand.hx
+++ b/test/hex/state/mock/DisplayAddBannerMockCommand.hx
@@ -9,10 +9,10 @@ import hex.control.command.BasicCommand;
 class DisplayAddBannerMockCommand extends BasicCommand
 {
 	@Inject
-	public var logger : IMockCommandLogger;
+	public var commandLogger : IMockCommandLogger;
 
 	override public function execute() : Void
 	{
-		this.logger.log( "DAB" );
+		this.commandLogger.log( "DAB" );
 	}
 }

--- a/test/hex/state/mock/DisplayWelcomeMessageMockCommand.hx
+++ b/test/hex/state/mock/DisplayWelcomeMessageMockCommand.hx
@@ -9,10 +9,10 @@ import hex.control.command.BasicCommand;
 class DisplayWelcomeMessageMockCommand extends BasicCommand
 {
 	@Inject
-	public var logger : IMockCommandLogger;
+	public var commandLogger : IMockCommandLogger;
 
 	override public function execute() : Void
 	{
-		this.logger.log( "DWM" );
+		this.commandLogger.log( "DWM" );
 	}
 }

--- a/test/hex/state/mock/GetAdminPrivilegesMockCommand.hx
+++ b/test/hex/state/mock/GetAdminPrivilegesMockCommand.hx
@@ -9,10 +9,10 @@ import hex.control.command.BasicCommand;
 class GetAdminPrivilegesMockCommand extends BasicCommand
 {
 	@Inject
-	public var logger : IMockCommandLogger;
+	public var commandLogger : IMockCommandLogger;
 
 	override public function execute() : Void
 	{
-		this.logger.log( "GAP" );
+		this.commandLogger.log( "GAP" );
 	}
 }

--- a/test/hex/state/mock/InviteForRegisterMockCommand.hx
+++ b/test/hex/state/mock/InviteForRegisterMockCommand.hx
@@ -10,7 +10,7 @@ import hex.control.async.AsyncCommand;
 class InviteForRegisterMockCommand extends AsyncCommand
 {
 	@Inject
-	public var logger : IMockCommandLogger;
+	public var commandLogger : IMockCommandLogger;
 
 	override public function execute() : Void
 	{
@@ -19,7 +19,7 @@ class InviteForRegisterMockCommand extends AsyncCommand
 	
 	function _execute() : Void
 	{
-		this.logger.log( "IFR" );
+		this.commandLogger.log( "IFR" );
 		this._handleComplete();
 	}
 }

--- a/test/hex/state/mock/MockCommandWithRequest.hx
+++ b/test/hex/state/mock/MockCommandWithRequest.hx
@@ -13,13 +13,13 @@ class MockCommandWithRequest extends BasicCommand
 	public var code : String;
 	
 	@Inject
-	public var logger : IMockCommandLogger;
+	public var commandLogger : IMockCommandLogger;
 	
 	@Inject
 	public var parser : IParser<String>;
 	
 	override public function execute() : Void
 	{
-		this.logger.log( this.parser.parse( this.code ) );
+		this.commandLogger.log( this.parser.parse( this.code ) );
 	}
 }

--- a/test/hex/state/mock/PrepareUserInfosMockCommand.hx
+++ b/test/hex/state/mock/PrepareUserInfosMockCommand.hx
@@ -9,10 +9,10 @@ import hex.control.command.BasicCommand;
 class PrepareUserInfosMockCommand extends BasicCommand
 {
 	@Inject
-	public var logger : IMockCommandLogger;
+	public var commandLogger : IMockCommandLogger;
 
 	override public function execute() : Void
 	{
-		this.logger.log( "PUI" );
+		this.commandLogger.log( "PUI" );
 	}
 }

--- a/test/hex/state/mock/RemoveAdminPrivilegesMockCommand.hx
+++ b/test/hex/state/mock/RemoveAdminPrivilegesMockCommand.hx
@@ -9,10 +9,10 @@ import hex.control.command.BasicCommand;
 class RemoveAdminPrivilegesMockCommand extends BasicCommand
 {
 	@Inject
-	public var logger : IMockCommandLogger;
+	public var commandLogger : IMockCommandLogger;
 
 	override public function execute() : Void
 	{
-		this.logger.log( "RAP" );
+		this.commandLogger.log( "RAP" );
 	}
 }

--- a/test/hex/state/mock/StoreUserActivityMockCommand.hx
+++ b/test/hex/state/mock/StoreUserActivityMockCommand.hx
@@ -10,10 +10,10 @@ import hex.control.command.BasicCommand;
 class StoreUserActivityMockCommand extends BasicCommand
 {
 	@Inject
-	public var logger : IMockCommandLogger;
+	public var commandLogger : IMockCommandLogger;
 
 	override public function execute() : Void
 	{
-		this.logger.log( "SUA" );
+		this.commandLogger.log( "SUA" );
 	}
 }


### PR DESCRIPTION
`logger` will be already defined in the base class